### PR TITLE
Fixed database dump name

### DIFF
--- a/lib/j-cap-recipes.rb
+++ b/lib/j-cap-recipes.rb
@@ -1,2 +1,3 @@
 require_relative 'j-cap-recipes/version'
+require_relative 'j-cap-recipes/util'
 require_relative 'j-cap-recipes/railtie' if defined?(Rails)

--- a/lib/j-cap-recipes/tasks/database.rake
+++ b/lib/j-cap-recipes/tasks/database.rake
@@ -46,7 +46,9 @@ namespace :db do
       within release_path do
         FileUtils.mkdir_p 'db/backups'
         env_name = args[:env_name] || fetch(:rails_env).to_s
-        backup_file = "db/backups/#{fetch(:application)}_#{env_name}_latest.dump"
+        database_config_content = read_remote_database_config
+        database_name = JCap::Recipes::Util.database_name(env_name, database_config_content)
+        backup_file = "db/backups/#{database_name}_latest.dump"
         download! "#{release_path}/#{backup_file}", backup_file
       end
     end
@@ -58,7 +60,9 @@ namespace :db do
       within release_path do
         FileUtils.mkdir_p 'db/backups'
         env_name = args[:env_name] || fetch(:rails_env).to_s
-        backup_file = "db/backups/#{fetch(:application)}_#{env_name}_latest.dump"
+        database_config_content = read_remote_database_config
+        database_name = JCap::Recipes::Util.database_name(env_name, database_config_content)
+        backup_file = "db/backups/#{database_name}_latest.dump"
         upload! backup_file, "#{release_path}/#{backup_file}"
       end
     end
@@ -94,4 +98,8 @@ file '/tmp/database.yml' do |t|
   File.open t.name, 'w' do |f|
     f.puts config.result(binding)
   end
+end
+
+def read_remote_database_config(path = 'config/database.yml')
+  capture :cat, path
 end

--- a/lib/j-cap-recipes/util.rb
+++ b/lib/j-cap-recipes/util.rb
@@ -1,0 +1,12 @@
+module JCap
+  module Recipes
+    module Util
+      class << self
+        def database_name(env_name, config_contents)
+          db_config = YAML.load(config_contents)
+          db_config[env_name][:database] || db_config[env_name]['database']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The database dump was saved using database name. But, the dump_download and dump_upload tasks used application name and env name to find the dump. Obviously, it was working only if the database is named using common conventions: 'app_name_environment'. But in some projects there are more meaningful names for dbs, so we need to parse them directly from config.
